### PR TITLE
[BA-479]: including blockhound configuration to the starter (RC 0.1.5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,12 @@ subprojects {
     targetCompatibility = sourceCompatibility = JavaVersion.VERSION_11
 
     dependencies {
+        implementation 'com.google.auto.service:auto-service:1.0'
+
+        implementation 'io.projectreactor.tools:blockhound:1.0.6.RELEASE'
+
         implementation platform('org.springframework.boot:spring-boot-dependencies:2.5.1')
+
         testImplementation 'org.junit.jupiter:junit-jupiter'
     }
 

--- a/starter/build.gradle
+++ b/starter/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok:1.18.20'
 
     implementation "org.springdoc:springdoc-openapi-webflux-core:1.5.8"
+    implementation 'io.projectreactor.tools:blockhound'
+    implementation 'com.google.auto.service:auto-service'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/starter/src/main/java/com/vivy/springdoc/SwaggerBlockHoundIntegration.java
+++ b/starter/src/main/java/com/vivy/springdoc/SwaggerBlockHoundIntegration.java
@@ -16,7 +16,6 @@ public class SwaggerBlockHoundIntegration implements BlockHoundIntegration {
                         "build"
                 );
     }
-
 }
 
 

--- a/starter/src/main/java/com/vivy/springdoc/SwaggerBlockHoundIntegration.java
+++ b/starter/src/main/java/com/vivy/springdoc/SwaggerBlockHoundIntegration.java
@@ -1,0 +1,22 @@
+package com.vivy.springdoc;
+
+import com.google.auto.service.AutoService;
+import reactor.blockhound.BlockHound;
+import reactor.blockhound.integration.BlockHoundIntegration;
+
+
+@AutoService(BlockHoundIntegration.class)
+public class SwaggerBlockHoundIntegration implements BlockHoundIntegration {
+
+    @Override
+    public void applyTo(BlockHound.Builder builder) {
+        builder
+                .allowBlockingCallsInside(
+                        org.springdoc.core.OpenAPIService.class.getName(),
+                        "build"
+                );
+    }
+
+}
+
+

--- a/starter/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/starter/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,0 +1,1 @@
+com.vivy.springdoc.SwaggerBlockHoundIntegration


### PR DESCRIPTION
Now all dependents will automatically do without extra blockhound setup